### PR TITLE
autostart: Pridane vypnutie screen a power saverov

### DIFF
--- a/misc/xmonad/autostart
+++ b/misc/xmonad/autostart
@@ -5,6 +5,13 @@ unclutter&
 
 # kill the previously running instance of infoboard
 kill `ps aux | grep server.py | grep -v grep | awk '{print $2}' | head -n 1`
+
+# disable power saving and screensavers
+setterm -blank 0
+setterm -powerdown 0
+xset s off
+xset s 0 0
+xset -dpms
  
 # start a new instance
 cd ~/infoboard/;python server.py


### PR DESCRIPTION
- Pridane prikazy, ktore by mali hned po starte zabranit, aby sa monitor
  niekedy dostal do nejakeho usporneho rezimu.

Signed-off-by: mr.Shu mr@shu.io

--------- >8 --------

@martin-sucha mal som s tymto taky dost velky problem, tak som to takto natvrdo vymyslel. Ak nemas nejake vyhrady, mergnem o par dni sam.
